### PR TITLE
feat: clippy & fmt rules

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+large-error-threshold        = 256
+too-many-arguments-threshold = 8

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,9 +1,23 @@
-# Specify the edition for style consistency
-style_edition = "2024"
+array_width                    = 80
+attr_fn_like_width             = 80
+chain_width                    = 80
+comment_width                  = 100
+condense_wildcard_suffixes     = true
+edition                        = "2024"
+fn_call_width                  = 80
+format_code_in_doc_comments    = true
+format_macro_matchers          = true
+group_imports                  = "StdExternalCrate"
+hex_literal_case               = "Lower"
+imports_granularity            = "Crate"
+match_block_trailing_comma     = true
+newline_style                  = "Unix"
+single_line_if_else_max_width  = 60
+single_line_let_else_max_width = 60
+struct_lit_width               = 40
+struct_variant_width           = 40
+use_field_init_shorthand       = true
+use_try_shorthand              = true
+wrap_comments                  = true
+ignore                         = ["tests/*"]
 
-# Set the maximum line length
-max_width = 100
-
-# Ignore specific files or directories from formatting
-# (on nightly only)
-# ignore = ["tests/*"]


### PR DESCRIPTION
Usage: 
`cargo fmt --all`
` cargo clippy --all-targets -- -D warnings `